### PR TITLE
Avoid unnecessary file count for zero threshold

### DIFF
--- a/cachelib/file.py
+++ b/cachelib/file.py
@@ -48,7 +48,10 @@ class FileSystemCache(BaseCache):
             if ex.errno != errno.EEXIST:
                 raise
 
-        self._update_count(value=len(self._list_dir()))
+        # If there are many files and a zero threshold,
+        # the list_dir can slow initialisation massively
+        if self._threshold != 0:
+            self._update_count(value=len(self._list_dir()))
 
     @property
     def _file_count(self):


### PR DESCRIPTION
When the threshold is set to zero, the update_count method returns without updates.  However, in the initialisation, the file list is still created.  This file list calculation is useless if the update_count is to return immediately, yet it has the potential to slow the initialisation significantly if there are many files.

This PR avoids the call to update_count and list_dir in the init, if the threshold is zero.  I did not want to make this modification in the list_dir method just in case others are using it for a different purpose.