### PR TITLE
Fix usage of redis cache on py2 fixes #4

### DIFF
--- a/cachelib/redis.py
+++ b/cachelib/redis.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 try:
     import cPickle as pickle
 except ImportError:  # pragma: no cover


### PR DESCRIPTION
Without this the redis import will fail on py2