### PR TITLE
Remove explicit CPickle import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,6 @@ Version 0.2.0
 
 Unreleased
 
--   :class:`cachelib.Simplecache` and :class:`cachelib.FileSystemCache` will
-  now first remove expired entries, followed by removal of older entries when
-  cleaning up.
-
 
 Version 0.1.1
 ------------

--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -1,16 +1,12 @@
 import errno
 import os
+import pickle
 import tempfile
 from hashlib import md5
 from time import time
 
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
-
-from cachelib.base import BaseCache
 from cachelib._compat import text_type
+from cachelib.base import BaseCache
 
 
 class FileSystemCache(BaseCache):

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -1,10 +1,9 @@
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
+import pickle
 
-from cachelib.base import BaseCache, _items
-from cachelib._compat import string_types, integer_types
+from cachelib._compat import integer_types
+from cachelib._compat import string_types
+from cachelib.base import _items
+from cachelib.base import BaseCache
 
 
 class RedisCache(BaseCache):

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -1,9 +1,5 @@
+import pickle
 from time import time
-
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
 
 from cachelib.base import BaseCache
 

--- a/src/cachelib/uwsgi.py
+++ b/src/cachelib/uwsgi.py
@@ -1,9 +1,5 @@
+import pickle
 import platform
-
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
 
 from cachelib.base import BaseCache
 


### PR DESCRIPTION
From [picke docs performance section](https://docs.python.org/3/library/pickle.html#performance) and [pickle source](https://github.com/python/cpython/blob/5b22dd87aa39087f07987f788a0bbd2464e2a8b5/Lib/pickle.py#L1348-L1352) importing cPickle directly isn't necessary for python 3 and will raise `ModuleNotFoundError`, so the code now imports pickle normally and cPickle will be transparently imported.