### PR TITLE
Adjust MemcachedCache inc and dec methods to initialize entries as specified by Basecache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Version 0.2.0
 Unreleased
 
 -   When attempting to access non-existent entries with :class:`Memcached`,
-    these will now be initialize with a given value ``delta`` as specified
+    these will now be initialized with a given value ``delta`` as specified
     in :class:`BaseCache`
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Version 0.2.0
 
 Unreleased
 
+-   When attempting to access non-existent entries with :class:`Memcached`,
+    these will now be initialize with a given value ``delta`` as specified
+    in :class:`BaseCache`
+
 
 Version 0.1.1
 ------------

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -150,11 +150,13 @@ class MemcachedCache(BaseCache):
 
     def inc(self, key, delta=1):
         key = self._normalize_key(key)
-        return self._client.incr(key, delta)
+        value = (self._client.get(key) or 0) + delta
+        return value if self.set(key, value) else None
 
     def dec(self, key, delta=1):
         key = self._normalize_key(key)
-        return self._client.decr(key, delta)
+        value = (self._client.get(key) or 0) - delta
+        return value if self.set(key, value) else None
 
     def import_preferred_memcache_lib(self, servers):
         """Returns an initialized memcache client.  Used by the constructor."""


### PR DESCRIPTION
[cachelib.MemcachedCache.inc](https://github.com/pallets/cachelib/blob/master/src/cachelib/memcached.py#L151) and [cachelib.MemcachedCache.dec](https://github.com/pallets/cachelib/blob/master/src/cachelib/memcached.py#L155) were not initializing entries to delta or -delta as specified in the [cachelib.BaseCahe](https://github.com/pallets/cachelib/blob/master/src/cachelib/base.py#L20) interface.

- [x] add changelog