### PR TITLE
Remove python version check in _compat.py

### DIFF
--- a/src/cachelib/_compat.py
+++ b/src/cachelib/_compat.py
@@ -1,27 +1,13 @@
 # flake8: noqa
 import sys
 
-PY2 = sys.version_info[0] == 2
-
-if PY2:
-    text_type = unicode
-    string_types = (str, unicode)
-    integer_types = (int, long)
-    iteritems = lambda d, *args, **kwargs: d.iteritems(*args, **kwargs)
-
-    def to_native(x, charset=sys.getdefaultencoding(), errors="strict"):
-        if x is None or isinstance(x, str):
-            return x
-        return x.encode(charset, errors)
+text_type = str
+string_types = (str,)
+integer_types = (int,)
+iteritems = lambda d, *args, **kwargs: iter(d.items(*args, **kwargs))
 
 
-else:
-    text_type = str
-    string_types = (str,)
-    integer_types = (int,)
-    iteritems = lambda d, *args, **kwargs: iter(d.items(*args, **kwargs))
-
-    def to_native(x, charset=sys.getdefaultencoding(), errors="strict"):
-        if x is None or isinstance(x, str):
-            return x
-        return x.decode(charset, errors)
+def to_native(x, charset=sys.getdefaultencoding(), errors="strict"):
+    if x is None or isinstance(x, str):
+        return x
+    return x.decode(charset, errors)


### PR DESCRIPTION
Since only python 3 is supported, there's no need for the [version check](https://github.com/pallets/cachelib/compare/master...northernSage:remove-compat-py-version-check?expand=1#diff-581477a589825efc3fd695c3302ab5d33d5204edd2fa176e2f81251e78a3eb25L4) in `_compat.py` anymore.