### PR TITLE
Fix file count not being updated in FileSystemCache.get and FileSystemCache.has

### DIFF
--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -124,6 +124,7 @@ class FileSystemCache(BaseCache):
                     return pickle.load(f)
                 else:
                     os.remove(filename)
+                    self._update_count(delta=-1)
                     return None
         except (OSError, pickle.PickleError):
             return None
@@ -183,6 +184,7 @@ class FileSystemCache(BaseCache):
                     return True
                 else:
                     os.remove(filename)
+                    self._update_count(delta=-1)
                     return False
         except (OSError, pickle.PickleError):
             return False


### PR DESCRIPTION
As described in #20, the file count was not being updated after `os.remove()` in `FileSystemCache`.