### PR TITLE
Fix CI tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-     - name: install external dependencies
+      - name: install external dependencies
         run: sudo apt-get install libmemcached-dev memcached redis-server
       - name: update pip
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,10 +25,15 @@ jobs:
       matrix:
         include:
           - {name: Linux, python: '3.9', os: ubuntu-latest, tox: py39}
+          - {name: Linux-Uwsgi, python: '3.9', os: ubuntu-latest, tox: py39uwsgi}
           - {name: Mac, python: '3.9', os: macos-latest, tox: py39}
+          - {name: Mac-Uwsgi, python: '3.9', os: macos-latest, tox: py39uwsgi}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
+          - {name: '3.8-uwsgi', python: '3.8', os: ubuntu-latest, tox: py38uwsgi}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
+          - {name: '3.7-uwsgi', python: '3.7', os: ubuntu-latest, tox: py37uwsgi}
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
+          - {name: '3.6-uwsgi', python: '3.6', os: ubuntu-latest, tox: py36uwsgi}
           - {name: Style, python: '3.8', os: ubuntu-latest, tox: style}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,6 @@ jobs:
       matrix:
         include:
           - {name: Linux, python: '3.9', os: ubuntu-latest, tox: py39}
-          - {name: Windows, python: '3.9', os: windows-latest, tox: py39}
           - {name: Mac, python: '3.9', os: macos-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
@@ -36,7 +35,11 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: install external dependencies
+      - name: install external dependencies macos
+        if: matrix.os == 'macos-latest'
+        run: brew install libmemcached memcached redis
+      - name: install external dependencies linux
+        if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install libmemcached-dev memcached redis-server
       - name: update pip
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+     - name: install external dependencies
+        run: sudo apt-get install libmemcached-dev memcached redis-server
       - name: update pip
         run: |
           pip install -U wheel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def redis_server(xprocess):
 
     class Starter(ProcessStarter):
         pattern = "[Rr]eady to accept connections"
-        args = ["redis-server"]
+        args = ["redis-server", "--port 6360"]
 
     xprocess.ensure(package_name, Starter)
     yield

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -9,7 +9,7 @@ from cachelib import RedisCache
 @pytest.fixture(autouse=True)
 def cache_factory(request):
     def _factory(self, *args, **kwargs):
-        rc = RedisCache(*args, **kwargs)
+        rc = RedisCache(*args, port=6360, **kwargs)
         rc._client.flushdb()
         return rc
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,13 +10,13 @@ setenv = TMPDIR = {envtmpdir}
 deps = -r requirements/tests.txt
 
 [testenv:py{39,38,37,36}]
-commands = pytest -rs --tb=short --basetemp={envtmpdir} {posargs}
+commands = pytest -rs --capture=tee-sys --tb=short --basetemp={envtmpdir} {posargs}
 
 [testenv:py{39,38,37,36}uwsgi]
 commands =
     uwsgi --python {envbindir}/pytest \
-          --pyargv '-rs --tb=short --basetemp={envtmpdir} {posargs} -kUwsgi' \
-          --cache2 name=default,items=100 --master
+          --pyargv '-rs --capture=tee-sys --tb=short --basetemp={envtmpdir} \
+          {posargs} -kUwsgi' --cache2 name=default,items=100 --master
 
     python {envtmpdir}/return_pytest_exit_code.py
 
@@ -32,9 +32,10 @@ commands = sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 [testenv:coverage]
 commands =
     uwsgi --python {envbindir}/coverage \
-          --pyargv 'run -m pytest -rs --tb=short --basetemp={envtmpdir} {posargs} -kUwsgi' \
+          --pyargv 'run -m pytest -rs --capture=tee-sys --tb=short \
+          --basetemp={envtmpdir} {posargs} -kUwsgi' \
           --cache2 name=default,items=100 --master
     python {envtmpdir}/return_pytest_exit_code.py
 
-    coverage run -a -m pytest --tb=short --basetemp={envtmpdir} {posargs}
+    coverage run -a -m pytest --capture=tee-sys --tb=short --basetemp={envtmpdir} {posargs}
     coverage report --fail-under=80


### PR DESCRIPTION
This fixes the missing external dependencies in CI for tests in `tests.yml` worflow. Also had to make some other adjustments like which port redis was listening on (CI complaining that the default port was already in use) and have pytest capture sys.out/err since streams are handled a bit different in CI apparently.

- [x] add missing dependencies (memcached, redis-server)
- [x] capture streams with `pytest` so process started is detected (could maybe use xprocess `startup_check` callback here instead)
- [x]  sort ou windows and macOS

Edit:
- [ ] replace manual package install with service containers