### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,19 +1,20 @@
 Version 0.2.0
 -------------
 
-Unreleased
+Released 2021-06-25
 
 -   Support for Python 2 has been dropped. Only Python 3.6 and above are
     supported.
 -   Fix ``FileSystemCache.set`` incorrectly considering value overrides
-    on existing keys as new cache entries.
+    on existing keys as new cache entries. :issue:`18`
 -   ``SimpleCache`` and ``FileSystemCache`` first remove expired
-    entries, followed by older entries, when cleaning up.
+    entries, followed by older entries, when cleaning up. :pr:`26`
 -   Fix problem where file count was not being updated in
     ``FileSystemCache.get`` and ``FileSystemCache.has`` after removals.
     :issue:`20`
 -   When attempting to access non-existent entries with ``Memcached``,
     these will now be initialized with a given value ``delta``.
+    :pr:`31`
 
 
 Version 0.1.1

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -15,4 +15,4 @@ __all__ = [
     "RedisCache",
     "UWSGICache",
 ]
-__version__ = "0.2.0.dev0"
+__version__ = "0.2.0"


### PR DESCRIPTION
Our 0.2.0 release 🎉 

**Change Summary**

_Public_

- Fix `cachelib.FileSystemCache.set` wrongfully considering value overrides on existing keys as new cache entries  #15

- `cachelib.Simplecache` and `cachelib.FileSystemCache` will now first remove expired entries, followed by removal of older entries when cleaning up #26

- Fix file count was not being updated in `FileSystemCache.get` and `FileSystemCache.has` after removals (`os.remove`) in `FileSystemCache`. #33

- When attempting to access non-existent entries with `Memcached`, these will now be initialized with a given value delta as specified in `BaseCache` #31

- Support for python 2 has been dropped. The supported releases are now python 3.6 and above.

_Internal_

- Test suite added with current code coverage around `90%` #25

- New Github Actions workflow added for CI [tests.yml](https://github.com/pallets/cachelib/blob/master/.github/workflows/tests.yaml) #35 and #25

- Old py2 `_compat.py` removed #41 