### PR TITLE
Remove hookwrapper=True from pytest_sessionfinish

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def under_uwsgi():
         return True
 
 
-@pytest.hookimpl(hookwrapper=True)
+@pytest.hookimpl()
 def pytest_sessionfinish(session, exitstatus):
     if under_uwsgi():
         try:
@@ -29,7 +29,6 @@ def pytest_sessionfinish(session, exitstatus):
         else:
             with open(script_path, mode="w") as f:
                 f.write(f"import sys; sys.exit({exitstatus})")
-    yield
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
`hookwrapper=True` is not necessary for `pytest_sessionfinish ` and it's actually incompatible with the hook itself. See [docs](https://docs.pytest.org/en/6.2.x/reference.html#pytest.hookspec.pytest_sessionfinish) for details on this.