### PR TITLE
Update workflow file to watch main branch instead of master

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@ name: Tests
 on:
   push:
     branches:
-      - master
+      - main
       - '*.x'
     paths-ignore:
       - 'docs/**'
@@ -10,7 +10,7 @@ on:
       - '*.rst'
   pull_request:
     branches:
-      - master
+      - main
       - '*.x'
     paths-ignore:
       - 'docs/**'


### PR DESCRIPTION
This just updates our CI workflow file to have it watch for PR's against `main` branch instead of `master`