### PR TITLE
Handle EOFError in FileSystemCache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Version 0.2.1
+-------------
+
+- Fix unhandled ``EOFError`` in ``FileSystemCache`` :issue:`20`
+
+
 Version 0.2.0
 -------------
 

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -16,9 +16,3 @@ __all__ = [
     "UWSGICache",
 ]
 __version__ = "0.2.0"
-
-
-import logging
-from logging import NullHandler
-
-logging.getLogger(__name__).addHandler(NullHandler())

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -16,3 +16,9 @@ __all__ = [
     "UWSGICache",
 ]
 __version__ = "0.2.0"
+
+
+import logging
+from logging import NullHandler
+
+logging.getLogger(__name__).addHandler(NullHandler())

--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -92,7 +92,7 @@ class FileSystemCache(BaseCache):
                 if expires != 0 and expires < now:
                     os.remove(fname)
                     self._update_count(delta=-1)
-            except OSError:
+            except (OSError, EOFError):
                 pass
 
     def _remove_older(self):
@@ -102,7 +102,7 @@ class FileSystemCache(BaseCache):
             try:
                 with open(fname, "rb") as f:
                     exp_fname_tuples.append((pickle.load(f), fname))
-            except OSError:
+            except (OSError, EOFError):
                 pass
         fname_sorted = (
             fname for _, fname in sorted(exp_fname_tuples, key=lambda item: item[1][0])
@@ -151,7 +151,7 @@ class FileSystemCache(BaseCache):
                     os.remove(filename)
                     self._update_count(delta=-1)
                     return None
-        except (OSError, pickle.PickleError):
+        except (OSError, EOFError, pickle.PickleError):
             return None
 
     def add(self, key, value, timeout=None):
@@ -212,5 +212,5 @@ class FileSystemCache(BaseCache):
                     os.remove(filename)
                     self._update_count(delta=-1)
                     return False
-        except (OSError, pickle.PickleError):
+        except (OSError, EOFError, pickle.PickleError):
             return False

--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -4,6 +4,7 @@ import os
 import pickle
 import tempfile
 from hashlib import md5
+from pathlib import Path
 from time import time
 
 from cachelib.base import BaseCache
@@ -205,6 +206,7 @@ class FileSystemCache(BaseCache):
                 pickle.dump(value, f, pickle.HIGHEST_PROTOCOL)
             os.replace(tmp, filename)
             os.chmod(filename, self._mode)
+            fsize = Path(filename).stat().st_size
         except OSError:
             logging.warning(
                 "Exception raised while handling cache file '%s'",
@@ -216,7 +218,7 @@ class FileSystemCache(BaseCache):
             # Management elements should not count towards threshold
             if not overwrite and not mgmt_element:
                 self._update_count(delta=1)
-            return True
+            return fsize > 0  # function should fail if file is empty
 
     def delete(self, key, mgmt_element=False):
         try:

--- a/tests/test_file_system_cache.py
+++ b/tests/test_file_system_cache.py
@@ -27,7 +27,7 @@ class TestFileSystemCache(CommonTests, ClearTests, HasTests):
         "cravettes": "mournay sauce",
     }
 
-    def test_EOFError(self):
+    def test_EOFError(self, caplog):
         cache = self.cache_factory(threshold=1)
         assert cache.set_many(self.sample_pairs)
         file_names = [cache._get_filename(k) for k in self.sample_pairs.keys()]
@@ -35,6 +35,7 @@ class TestFileSystemCache(CommonTests, ClearTests, HasTests):
         for fpath in file_names:
             open(fpath, "w").close()
         assert cache.set("test", "EOFError")
+        assert "Exception raised" in caplog.text
 
     def test_threshold(self):
         threshold = len(self.sample_pairs) // 2

--- a/tests/test_file_system_cache.py
+++ b/tests/test_file_system_cache.py
@@ -27,6 +27,15 @@ class TestFileSystemCache(CommonTests, ClearTests, HasTests):
         "cravettes": "mournay sauce",
     }
 
+    def test_EOFError(self):
+        cache = self.cache_factory(threshold=1)
+        assert cache.set_many(self.sample_pairs)
+        file_names = [cache._get_filename(k) for k in self.sample_pairs.keys()]
+        # truncate files to erase content
+        for fpath in file_names:
+            open(fpath, "w").close()
+        assert cache.set("test", "EOFError")
+
     def test_threshold(self):
         threshold = len(self.sample_pairs) // 2
         cache = self.cache_factory(threshold=threshold)


### PR DESCRIPTION
Addresses #21

- [x] handle `EOFError`
- [x] add change log
- [x] add warning about corrupted cache files
- [x] add tests covering handling of empty cache files
- [x] add extra check to `FileSystemCache.set` to ensure empty files are not being created