### PR TITLE
Separate cache file deletion from query logic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,14 @@ Unreleased
 -   Fix bug in ``FileSystemCache`` where entries would not be removed
     when total count was over threshold and entry count would be lost
 -   ``FileSystemCache`` will now log system-related exceptions
+-   Removal of expired entries in ``FileSystemCache`` will only be
+    triggered if the total number of entries is over the defined
+    ``threshhold`` when attempting to ``FileSystemCache.set``.
+    ``FileSystemCache.get`` and ``FileSystemCache.has`` will still
+    return ``None`` and ``False`` (respectively) for expired entries
+    but they will not remove the entry files. All removals will now
+    be conducted at prunning time or explicitly with ``clear`` and
+    ``delete``.
 
 
 Version 0.2.0

--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -164,8 +164,6 @@ class FileSystemCache(BaseCache):
                 if pickle_time == 0 or pickle_time >= time():
                     return pickle.load(f)
                 else:
-                    os.remove(filename)
-                    self._update_count(delta=-1)
                     return None
         except (OSError, EOFError, pickle.PickleError):
             logging.warning(
@@ -236,9 +234,9 @@ class FileSystemCache(BaseCache):
                 if pickle_time == 0 or pickle_time >= time():
                     return True
                 else:
-                    os.remove(filename)
-                    self._update_count(delta=-1)
                     return False
+        except FileNotFoundError:  # it there is no file there is no key
+            return False
         except (OSError, EOFError, pickle.PickleError):
             logging.warning(
                 "Exception raised while handling cache file '%s'",

--- a/tests/test_file_system_cache.py
+++ b/tests/test_file_system_cache.py
@@ -69,9 +69,9 @@ class TestFileSystemCache(CommonTests, ClearTests, HasTests):
         cache = self.cache_factory(threshold=threshold)
         for k, v in self.sample_pairs.items():
             assert cache.set(f"{k}-t1", v, timeout=1)
-            assert cache.set(f"{k}-t5", v, timeout=5)
+            assert cache.set(f"{k}-t10", v, timeout=10)
         sleep(3)
         for k, v in self.sample_pairs.items():
             assert cache.set(k, v)
-            assert cache.has(f"{k}-t5")
+            assert cache.has(f"{k}-t10")
             assert not cache.has(f"{k}-t1")


### PR DESCRIPTION
`FileSystemCache.get` and `FileSystemCache.has` will now only **get** and check if the current cache state **has** keys, respectively, as their names imply. I have kept the file deletion logic to the pruning stage and to the explicit removal methods `FileSystemCache.clear` and `FileSystemCache.delete`, only. This makes for a better separation of concerns. 

We also handle `FileNotFoundError` differently in `FileSystemCache.has`. If the file does not exist that means the key does not exist, so it was either not set or has been removed, we return `False` in both cases.