### PR TITLE
Change: pip link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Install and update using `pip`_:
 
     $ pip install -U cachelib
 
-.. _pip: https://pip.pypa.io/en/stable/quickstart/
+.. _pip: https://pip.pypa.io/en/stable/getting-started/
 
 
 Donate


### PR DESCRIPTION
Update link to pip documentation in README.rst from https://pip.pypa.io/en/stable/quickstart/ to https://pip.pypa.io/en/stable/getting-started/