### PR TITLE
Configurable Serialization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Version 0.5.0
+-------------
+
+Unreleased
+
+-   Cache types now have configurable serializers. :pr:`63`
+
+
 Version 0.4.1
 -------------
 
@@ -12,7 +20,6 @@ Version 0.4.0
 
 Released 2021-10-03
 
--   Add configurable serialization. :pr:`63`
 -   All cache types now implement ``BaseCache`` interface both
     in behavior and method return types. Thus, code written
     for one cache type should work with any other cache type. :pr:`71`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ Version 0.4.0
 
 Unreleased
 
+-   Add configurable serialization. :pr:`63`
 -   Add type information for static typing tools. :pr:`48`
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ testpaths = tests
 filterwarnings =
     error
     default::DeprecationWarning:cachelib.uwsgi
+    default::DeprecationWarning:cachelib.redis
 
 [coverage:run]
 branch = True

--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -8,11 +8,7 @@ from pathlib import Path
 from time import time
 
 from cachelib.base import BaseCache
-from cachelib.serializers import BaseSerializer
 from cachelib.serializers import FileSystemSerializer
-
-
-default_serializer = FileSystemSerializer()
 
 
 class FileSystemCache(BaseCache):
@@ -36,19 +32,19 @@ class FileSystemCache(BaseCache):
     #: keep amount of files in a cache element
     _fs_count_file = "__wz_cache_count"
 
+    serializer = FileSystemSerializer()
+
     def __init__(
         self,
         cache_dir: str,
         threshold: int = 500,
         default_timeout: int = 300,
         mode: int = 0o600,
-        serializer: BaseSerializer = default_serializer,
     ):
         BaseCache.__init__(self, default_timeout)
         self._path = cache_dir
         self._threshold = threshold
         self._mode = mode
-        self.serializer = serializer
 
         try:
             os.makedirs(self._path)

--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -33,7 +33,7 @@ class FileSystemCache(BaseCache):
     _fs_count_file = "__wz_cache_count"
 
     # override this to customize serialization strategy
-    serializer = FileSystemSerializer
+    serializer = FileSystemSerializer()
 
     def __init__(
         self,

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -72,7 +72,7 @@ class RedisCache(BaseCache):
         )
         return self.serializer.dumps(value)
 
-    def load_object(self, value: _t.Optional[bytes]) -> _t.Any:
+    def load_object(self, value: _t.Any) -> _t.Any:
         warnings.warn(
             "'load_object' is deprecated and will be removed in the future."
             "This is a proxy call to 'RedisCache.serializer.loads'",

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -2,7 +2,10 @@ import typing as _t
 import warnings
 
 from cachelib.base import BaseCache
+from cachelib.serializers import BaseSerializer
 from cachelib.serializers import RedisSerializer
+
+default_serializer = RedisSerializer()
 
 
 class RedisCache(BaseCache):
@@ -27,8 +30,6 @@ class RedisCache(BaseCache):
     Any additional keyword arguments will be passed to ``redis.Redis``.
     """
 
-    serializer = RedisSerializer()
-
     def __init__(
         self,
         host: str = "localhost",
@@ -37,8 +38,10 @@ class RedisCache(BaseCache):
         db: int = 0,
         default_timeout: int = 300,
         key_prefix: _t.Optional[str] = None,
+        serializer: BaseSerializer = default_serializer,
         **kwargs: _t.Any
     ):
+        self.serializer = serializer
         BaseCache.__init__(self, default_timeout)
         if host is None:
             raise ValueError("RedisCache host parameter may not be None")

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -27,8 +27,7 @@ class RedisCache(BaseCache):
     Any additional keyword arguments will be passed to ``redis.Redis``.
     """
 
-    # override this to customize serialization strategy
-    serializer = RedisSerializer
+    serializer = RedisSerializer()
 
     def __init__(
         self,
@@ -64,20 +63,20 @@ class RedisCache(BaseCache):
     def dump_object(self, value: _t.Any) -> bytes:
         warnings.warn(
             "'dump_object' is deprecated and will be removed in the future."
-            "This is a proxy call to 'RedisCache.serializer.dump'",
+            "This is a proxy call to 'RedisCache.serializer.dumps'",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.serializer.dump(value)
+        return self.serializer.dumps(value)
 
     def load_object(self, value: _t.Optional[bytes]) -> _t.Any:
         warnings.warn(
             "'load_object' is deprecated and will be removed in the future."
-            "This is a proxy call to 'RedisCache.serializer.load'",
+            "This is a proxy call to 'RedisCache.serializer.loads'",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.serializer.load(value)
+        return self.serializer.loads(value)
 
     def get(self, key: str) -> _t.Any:
         return self.load_object(self._client.get(self.key_prefix + key))

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -2,10 +2,7 @@ import typing as _t
 import warnings
 
 from cachelib.base import BaseCache
-from cachelib.serializers import BaseSerializer
 from cachelib.serializers import RedisSerializer
-
-default_serializer = RedisSerializer()
 
 
 class RedisCache(BaseCache):
@@ -30,6 +27,8 @@ class RedisCache(BaseCache):
     Any additional keyword arguments will be passed to ``redis.Redis``.
     """
 
+    serializer = RedisSerializer()
+
     def __init__(
         self,
         host: str = "localhost",
@@ -38,18 +37,16 @@ class RedisCache(BaseCache):
         db: int = 0,
         default_timeout: int = 300,
         key_prefix: _t.Optional[str] = None,
-        serializer: BaseSerializer = default_serializer,
         **kwargs: _t.Any
     ):
-        self.serializer = serializer
         BaseCache.__init__(self, default_timeout)
         if host is None:
             raise ValueError("RedisCache host parameter may not be None")
         if isinstance(host, str):
             try:
                 import redis
-            except ImportError:
-                raise RuntimeError("no redis module found")
+            except ImportError as e:
+                raise RuntimeError("no redis module found") from e
             if kwargs.get("decode_responses", None):
                 raise ValueError("decode_responses is not supported by RedisCache.")
             self._client = redis.Redis(

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -1,37 +1,8 @@
-import pickle
 import typing as _t
 import warnings
 
 from cachelib.base import BaseCache
-
-
-class RedisSerializer:
-    @staticmethod
-    def dump(value: _t.Any) -> bytes:
-        """Dumps an object into a string for redis.  By default it serializes
-        integers as regular string and pickle dumps everything else.
-        """
-        if isinstance(type(value), int):
-            return str(value).encode("ascii")
-        return b"!" + pickle.dumps(value)
-
-    @staticmethod
-    def load(value: _t.Optional[bytes]) -> _t.Any:
-        """The reversal of :meth:`dump_object`.  This might be called with
-        None.
-        """
-        if value is None:
-            return None
-        if value.startswith(b"!"):
-            try:
-                return pickle.loads(value[1:])
-            except pickle.PickleError:
-                return None
-        try:
-            return int(value)
-        except ValueError:
-            # before 0.8 we did not have serialization. Still support that.
-            return value
+from cachelib.serializers import RedisSerializer
 
 
 class RedisCache(BaseCache):

--- a/src/cachelib/serializers.py
+++ b/src/cachelib/serializers.py
@@ -1,0 +1,114 @@
+import logging
+import pickle
+import typing as _t
+from io import BufferedWriter
+
+
+class FileSystemSerializer:
+    @staticmethod
+    def dump(
+        timeout: int, f: BufferedWriter, protocol: int = pickle.HIGHEST_PROTOCOL
+    ) -> None:
+        try:
+            pickle.dump(timeout, f, protocol)
+        except (pickle.PickleError, pickle.PicklingError) as e:
+            logging.warning(
+                f"An exception has been raised during a pickling operation: {e}"
+            )
+
+    @staticmethod
+    def load(f: _t.BinaryIO) -> _t.Any:
+        try:
+            data = pickle.load(f)
+        except pickle.PickleError as e:
+            logging.warning(
+                f"An exception has been raised during an unplicking operation: {e}"
+            )
+            return None
+        else:
+            return data
+
+
+class RedisSerializer:
+    @staticmethod
+    def dump(value: _t.Any) -> bytes:
+        """Dumps an object into a string for redis.  By default it serializes
+        integers as regular string and pickle dumps everything else.
+        """
+        if isinstance(type(value), int):
+            return str(value).encode("ascii")
+        return b"!" + pickle.dumps(value)
+
+    @staticmethod
+    def load(value: _t.Optional[bytes]) -> _t.Any:
+        """The reversal of :meth:`dump_object`.  This might be called with
+        None.
+        """
+        if value is None:
+            return None
+        if value.startswith(b"!"):
+            try:
+                return pickle.loads(value[1:])
+            except pickle.PickleError:
+                return None
+        try:
+            return int(value)
+        except ValueError:
+            # before 0.8 we did not have serialization. Still support that.
+            return value
+
+
+class SimpleSerializer:
+    @staticmethod
+    def dump(
+        value: _t.Any, protocol: int = pickle.HIGHEST_PROTOCOL
+    ) -> _t.Optional[bytes]:
+        try:
+            serialized = pickle.dumps(value, protocol)
+        except (pickle.PickleError, pickle.PicklingError) as e:
+            logging.warning(
+                f"An exception has been raised during a pickling operation: {e}"
+            )
+            return None
+        else:
+            return serialized
+
+    @staticmethod
+    def load(bvalue: bytes) -> _t.Any:
+        try:
+            data = pickle.loads(bvalue)
+        except pickle.PickleError as e:
+            logging.warning(
+                f"An exception has been raised during an unplicking operation: {e}"
+            )
+            return None
+        else:
+            return data
+
+
+class UWSGISerializer:
+    @staticmethod
+    def dump(
+        value: _t.Any, protocol: int = pickle.HIGHEST_PROTOCOL
+    ) -> _t.Optional[bytes]:
+        try:
+            serialized = pickle.dumps(value, protocol)
+        except (pickle.PickleError, pickle.PicklingError) as e:
+            logging.warning(
+                f"An exception has been raised during a pickling operation: {e}"
+            )
+            return None
+        else:
+            return serialized
+
+    @staticmethod
+    def load(bvalue: bytes) -> _t.Any:
+        try:
+            data = pickle.loads(bvalue)
+        except pickle.PickleError as e:
+            logging.warning(
+                f"An exception has been raised during an unplicking operation: {e}"
+            )
+            return None
+        else:
+            return data

--- a/src/cachelib/serializers.py
+++ b/src/cachelib/serializers.py
@@ -1,47 +1,117 @@
 import logging
 import pickle
 import typing as _t
-from io import BufferedWriter
 
 
-class FileSystemSerializer:
-    @staticmethod
+class BaseSerializer:
+    """This is the base interface for all default serializers.
+
+    BaseSerializer.load and BaseSerializer.dump
+    will default to pickle.loads and pickle.dumps
+    as do default serializers for most of the cache types.
+    """
+
+    def _warn(self, e: pickle.PickleError) -> None:
+        logging.warning(
+            f"An exception has been raised during a pickling operation: {e}"
+        )
+
     def dump(
-        timeout: int, f: BufferedWriter, protocol: int = pickle.HIGHEST_PROTOCOL
+        self, serialized: int, f: _t.IO, protocol: int = pickle.HIGHEST_PROTOCOL
     ) -> None:
         try:
-            pickle.dump(timeout, f, protocol)
+            pickle.dump(serialized, f, protocol)
         except (pickle.PickleError, pickle.PicklingError) as e:
-            logging.warning(
-                f"An exception has been raised during a pickling operation: {e}"
-            )
+            self._warn(e)
 
-    @staticmethod
-    def load(f: _t.BinaryIO) -> _t.Any:
+    def load(self, f: _t.BinaryIO) -> _t.Any:
         try:
             data = pickle.load(f)
         except pickle.PickleError as e:
-            logging.warning(
-                f"An exception has been raised during an unplicking operation: {e}"
-            )
+            self._warn(e)
+            return None
+        else:
+            return data
+
+    """BaseSerializer.loads and BaseSerializer.dumps
+    work on top of pickle.loads and pickle.dumps. For now,
+    these two methods are only used in FileSystemCache.
+    """
+
+    def dumps(
+        self, value: _t.Any, protocol: int = pickle.HIGHEST_PROTOCOL
+    ) -> _t.Optional[bytes]:
+        try:
+            serialized = pickle.dumps(value, protocol)
+        except (pickle.PickleError, pickle.PicklingError) as e:
+            self._warn(e)
+            return None
+        else:
+            return serialized
+
+    def loads(self, bvalue: bytes) -> _t.Any:
+        try:
+            data = pickle.loads(bvalue)
+        except pickle.PickleError as e:
+            self._warn(e)
             return None
         else:
             return data
 
 
-class RedisSerializer:
-    @staticmethod
-    def dump(value: _t.Any) -> bytes:
-        """Dumps an object into a string for redis.  By default it serializes
+class UWSGISerializer(BaseSerializer):
+    """Default serializer for UWSGICache.
+
+    This class can be used to further customize the
+    behaviour specific to UWSGICache serialization.
+    Alternatively, UWSGISerializer.serializer can be
+    overriden in order to use a custom serializer with
+    a different strategy altogether.
+    """
+
+
+class SimpleSerializer(BaseSerializer):
+    """Default serializer for SimpleCache.
+
+    This class can be used to further customize the
+    behaviour specific to SimpleCache serialization.
+    Alternatively, SimpleSerializer.serializer can be
+    overriden in order to use a custom serializer with
+    a different strategy altogether.
+    """
+
+
+class FileSystemSerializer(BaseSerializer):
+    """Default serializer for FileSystemCache.
+
+    This class can be used to further customize the
+    behaviour specific to FileSystemCache serialization.
+    Alternatively, FileSystemCache.serializer can be
+    overriden in order to use a custom serializer with
+    a different strategy altogether.
+    """
+
+
+class RedisSerializer(BaseSerializer):
+    """Default serializer for RedisCache.
+
+    This class can be used to further customize the
+    behaviour specific to RedisCache serialization.
+    Alternatively, RedisCache.serializer can be
+    overriden in order to use a custom serializer with
+    a different strategy altogether.
+    """
+
+    def dumps(self, value: _t.Any, protocol: int = pickle.HIGHEST_PROTOCOL) -> bytes:
+        """Dumps an object into a string for redis. By default it serializes
         integers as regular string and pickle dumps everything else.
         """
         if isinstance(type(value), int):
             return str(value).encode("ascii")
-        return b"!" + pickle.dumps(value)
+        return b"!" + pickle.dumps(value, protocol)
 
-    @staticmethod
-    def load(value: _t.Optional[bytes]) -> _t.Any:
-        """The reversal of :meth:`dump_object`.  This might be called with
+    def loads(self, value: _t.Optional[bytes]) -> _t.Any:
+        """The reversal of :meth:`dump_object`. This might be called with
         None.
         """
         if value is None:
@@ -56,59 +126,3 @@ class RedisSerializer:
         except ValueError:
             # before 0.8 we did not have serialization. Still support that.
             return value
-
-
-class SimpleSerializer:
-    @staticmethod
-    def dump(
-        value: _t.Any, protocol: int = pickle.HIGHEST_PROTOCOL
-    ) -> _t.Optional[bytes]:
-        try:
-            serialized = pickle.dumps(value, protocol)
-        except (pickle.PickleError, pickle.PicklingError) as e:
-            logging.warning(
-                f"An exception has been raised during a pickling operation: {e}"
-            )
-            return None
-        else:
-            return serialized
-
-    @staticmethod
-    def load(bvalue: bytes) -> _t.Any:
-        try:
-            data = pickle.loads(bvalue)
-        except pickle.PickleError as e:
-            logging.warning(
-                f"An exception has been raised during an unplicking operation: {e}"
-            )
-            return None
-        else:
-            return data
-
-
-class UWSGISerializer:
-    @staticmethod
-    def dump(
-        value: _t.Any, protocol: int = pickle.HIGHEST_PROTOCOL
-    ) -> _t.Optional[bytes]:
-        try:
-            serialized = pickle.dumps(value, protocol)
-        except (pickle.PickleError, pickle.PicklingError) as e:
-            logging.warning(
-                f"An exception has been raised during a pickling operation: {e}"
-            )
-            return None
-        else:
-            return serialized
-
-    @staticmethod
-    def load(bvalue: bytes) -> _t.Any:
-        try:
-            data = pickle.loads(bvalue)
-        except pickle.PickleError as e:
-            logging.warning(
-                f"An exception has been raised during an unplicking operation: {e}"
-            )
-            return None
-        else:
-            return data

--- a/src/cachelib/serializers.py
+++ b/src/cachelib/serializers.py
@@ -38,16 +38,12 @@ class BaseSerializer:
     strings and byte strings is the default for most cache types.
     """
 
-    def dumps(
-        self, value: _t.Any, protocol: int = pickle.HIGHEST_PROTOCOL
-    ) -> _t.Optional[bytes]:
+    def dumps(self, value: _t.Any, protocol: int = pickle.HIGHEST_PROTOCOL) -> bytes:
         try:
             serialized = pickle.dumps(value, protocol)
         except (pickle.PickleError, pickle.PicklingError) as e:
             self._warn(e)
-            return None
-        else:
-            return serialized
+        return serialized
 
     def loads(self, bvalue: bytes) -> _t.Any:
         try:

--- a/src/cachelib/serializers.py
+++ b/src/cachelib/serializers.py
@@ -6,9 +6,9 @@ import typing as _t
 class BaseSerializer:
     """This is the base interface for all default serializers.
 
-    BaseSerializer.load and BaseSerializer.dump
-    will default to pickle.loads and pickle.dumps
-    as do default serializers for most of the cache types.
+    BaseSerializer.load and BaseSerializer.dump will
+    default to pickle.load and pickle.dump. This is currently
+    used only by FileSystemCache which dumps/loads to/from a file stream.
     """
 
     def _warn(self, e: pickle.PickleError) -> None:
@@ -17,10 +17,10 @@ class BaseSerializer:
         )
 
     def dump(
-        self, serialized: int, f: _t.IO, protocol: int = pickle.HIGHEST_PROTOCOL
+        self, value: int, f: _t.IO, protocol: int = pickle.HIGHEST_PROTOCOL
     ) -> None:
         try:
-            pickle.dump(serialized, f, protocol)
+            pickle.dump(value, f, protocol)
         except (pickle.PickleError, pickle.PicklingError) as e:
             self._warn(e)
 
@@ -34,8 +34,8 @@ class BaseSerializer:
             return data
 
     """BaseSerializer.loads and BaseSerializer.dumps
-    work on top of pickle.loads and pickle.dumps. For now,
-    these two methods are only used in FileSystemCache.
+    work on top of pickle.loads and pickle.dumps. Dumping/loading
+    strings and byte strings is the default for most cache types.
     """
 
     def dumps(

--- a/src/cachelib/serializers.py
+++ b/src/cachelib/serializers.py
@@ -59,48 +59,29 @@ class BaseSerializer:
             return data
 
 
-class UWSGISerializer(BaseSerializer):
-    """Default serializer for UWSGICache.
+"""Default serializers for each cache type.
 
-    This class can be used to further customize the
-    behaviour specific to UWSGICache serialization.
-    Alternatively, UWSGISerializer.serializer can be
-    overriden in order to use a custom serializer with
-    a different strategy altogether.
-    """
+The following classes can be used to further customize
+serialiation behaviour. Alternatively, any serializer can be
+overriden in order to use a custom serializer with a different
+strategy altogether.
+"""
+
+
+class UWSGISerializer(BaseSerializer):
+    """Default serializer for UWSGICache."""
 
 
 class SimpleSerializer(BaseSerializer):
-    """Default serializer for SimpleCache.
-
-    This class can be used to further customize the
-    behaviour specific to SimpleCache serialization.
-    Alternatively, SimpleSerializer.serializer can be
-    overriden in order to use a custom serializer with
-    a different strategy altogether.
-    """
+    """Default serializer for SimpleCache."""
 
 
 class FileSystemSerializer(BaseSerializer):
-    """Default serializer for FileSystemCache.
-
-    This class can be used to further customize the
-    behaviour specific to FileSystemCache serialization.
-    Alternatively, FileSystemCache.serializer can be
-    overriden in order to use a custom serializer with
-    a different strategy altogether.
-    """
+    """Default serializer for FileSystemCache."""
 
 
 class RedisSerializer(BaseSerializer):
-    """Default serializer for RedisCache.
-
-    This class can be used to further customize the
-    behaviour specific to RedisCache serialization.
-    Alternatively, RedisCache.serializer can be
-    overriden in order to use a custom serializer with
-    a different strategy altogether.
-    """
+    """Default serializer for RedisCache."""
 
     def dumps(self, value: _t.Any, protocol: int = pickle.HIGHEST_PROTOCOL) -> bytes:
         """Dumps an object into a string for redis. By default it serializes

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -19,7 +19,7 @@ class SimpleCache(BaseCache):
                             0 indicates that the cache never expires.
     """
 
-    serializer = SimpleSerializer
+    serializer = SimpleSerializer()
 
     def __init__(self, threshold: int = 500, default_timeout: int = 300):
         BaseCache.__init__(self, default_timeout)
@@ -66,20 +66,20 @@ class SimpleCache(BaseCache):
         try:
             expires, value = self._cache[key]
             if expires == 0 or expires > time():
-                return self.serializer.load(value)
+                return self.serializer.loads(value)
         except KeyError:
             return None
 
     def set(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> bool:
         expires = self._normalize_timeout(timeout)
         self._prune()
-        self._cache[key] = (expires, self.serializer.dump(value))
+        self._cache[key] = (expires, self.serializer.dumps(value))
         return True
 
     def add(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> bool:
         expires = self._normalize_timeout(timeout)
         self._prune()
-        item = (expires, self.serializer.dump(value))
+        item = (expires, self.serializer.dumps(value))
         if key in self._cache:
             return False
         self._cache.setdefault(key, item)

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -1,37 +1,8 @@
-import logging
-import pickle
 import typing as _t
 from time import time
 
 from cachelib.base import BaseCache
-
-
-class SimpleSerializer:
-    @staticmethod
-    def dump(
-        value: _t.Any, protocol: int = pickle.HIGHEST_PROTOCOL
-    ) -> _t.Optional[bytes]:
-        try:
-            serialized = pickle.dumps(value, protocol)
-        except (pickle.PickleError, pickle.PicklingError) as e:
-            logging.warning(
-                f"An exception has been raised during a pickling operation: {e}"
-            )
-            return None
-        else:
-            return serialized
-
-    @staticmethod
-    def load(bvalue: bytes) -> _t.Any:
-        try:
-            data = pickle.loads(bvalue)
-        except pickle.PickleError as e:
-            logging.warning(
-                f"An exception has been raised during an unplicking operation: {e}"
-            )
-            return None
-        else:
-            return data
+from cachelib.serializers import SimpleSerializer
 
 
 class SimpleCache(BaseCache):

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -2,7 +2,10 @@ import typing as _t
 from time import time
 
 from cachelib.base import BaseCache
+from cachelib.serializers import BaseSerializer
 from cachelib.serializers import SimpleSerializer
+
+default_serializer = SimpleSerializer()
 
 
 class SimpleCache(BaseCache):
@@ -19,14 +22,18 @@ class SimpleCache(BaseCache):
                             0 indicates that the cache never expires.
     """
 
-    serializer = SimpleSerializer()
-
-    def __init__(self, threshold: int = 500, default_timeout: int = 300):
+    def __init__(
+        self,
+        threshold: int = 500,
+        default_timeout: int = 300,
+        serializer: BaseSerializer = default_serializer,
+    ):
         BaseCache.__init__(self, default_timeout)
         self._cache: _t.Dict[str, _t.Any] = {}
         # mypy complains about mocks
         self.clear = self._cache.clear  # type: ignore
         self._threshold = threshold or 500  # threshold = 0
+        self.serializer = serializer
 
     def _over_threshold(self) -> bool:
         return len(self._cache) > self._threshold

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -2,10 +2,7 @@ import typing as _t
 from time import time
 
 from cachelib.base import BaseCache
-from cachelib.serializers import BaseSerializer
 from cachelib.serializers import SimpleSerializer
-
-default_serializer = SimpleSerializer()
 
 
 class SimpleCache(BaseCache):
@@ -22,18 +19,18 @@ class SimpleCache(BaseCache):
                             0 indicates that the cache never expires.
     """
 
+    serializer = SimpleSerializer()
+
     def __init__(
         self,
         threshold: int = 500,
         default_timeout: int = 300,
-        serializer: BaseSerializer = default_serializer,
     ):
         BaseCache.__init__(self, default_timeout)
         self._cache: _t.Dict[str, _t.Any] = {}
         # mypy complains about mocks
         self.clear = self._cache.clear  # type: ignore
         self._threshold = threshold or 500  # threshold = 0
-        self.serializer = serializer
 
     def _over_threshold(self) -> bool:
         return len(self._cache) > self._threshold

--- a/src/cachelib/uwsgi.py
+++ b/src/cachelib/uwsgi.py
@@ -2,7 +2,10 @@ import platform
 import typing as _t
 
 from cachelib.base import BaseCache
+from cachelib.serializers import BaseSerializer
 from cachelib.serializers import UWSGISerializer
+
+default_serializer = UWSGISerializer()
 
 
 class UWSGICache(BaseCache):
@@ -20,10 +23,15 @@ class UWSGICache(BaseCache):
         the cache.
     """
 
-    serializer = UWSGISerializer()
-
-    def __init__(self, default_timeout: int = 300, cache: str = ""):
+    def __init__(
+        self,
+        default_timeout: int = 300,
+        cache: str = "",
+        serializer: BaseSerializer = default_serializer,
+    ):
         BaseCache.__init__(self, default_timeout)
+
+        self.serializer = serializer
 
         if platform.python_implementation() == "PyPy":
             raise RuntimeError(

--- a/src/cachelib/uwsgi.py
+++ b/src/cachelib/uwsgi.py
@@ -20,7 +20,7 @@ class UWSGICache(BaseCache):
         the cache.
     """
 
-    serializer = UWSGISerializer
+    serializer = UWSGISerializer()
 
     def __init__(self, default_timeout: int = 300, cache: str = ""):
         BaseCache.__init__(self, default_timeout)
@@ -46,7 +46,7 @@ class UWSGICache(BaseCache):
         rv = self._uwsgi.cache_get(key, self.cache)
         if rv is None:
             return
-        return self.serializer.load(rv)
+        return self.serializer.loads(rv)
 
     def delete(self, key: str) -> _t.Any:
         return self._uwsgi.cache_del(key, self.cache)
@@ -54,7 +54,7 @@ class UWSGICache(BaseCache):
     def set(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> _t.Any:
         return self._uwsgi.cache_update(
             key,
-            self.serializer.dump(value),
+            self.serializer.dumps(value),
             self._normalize_timeout(timeout),
             self.cache,
         )
@@ -62,7 +62,7 @@ class UWSGICache(BaseCache):
     def add(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> _t.Any:
         return self._uwsgi.cache_set(
             key,
-            self.serializer.dump(value),
+            self.serializer.dumps(value),
             self._normalize_timeout(timeout),
             self.cache,
         )

--- a/src/cachelib/uwsgi.py
+++ b/src/cachelib/uwsgi.py
@@ -2,10 +2,7 @@ import platform
 import typing as _t
 
 from cachelib.base import BaseCache
-from cachelib.serializers import BaseSerializer
 from cachelib.serializers import UWSGISerializer
-
-default_serializer = UWSGISerializer()
 
 
 class UWSGICache(BaseCache):
@@ -23,15 +20,14 @@ class UWSGICache(BaseCache):
         the cache.
     """
 
+    serializer = UWSGISerializer()
+
     def __init__(
         self,
         default_timeout: int = 300,
         cache: str = "",
-        serializer: BaseSerializer = default_serializer,
     ):
         BaseCache.__init__(self, default_timeout)
-
-        self.serializer = serializer
 
         if platform.python_implementation() == "PyPy":
             raise RuntimeError(
@@ -43,10 +39,10 @@ class UWSGICache(BaseCache):
             import uwsgi  # type: ignore
 
             self._uwsgi = uwsgi
-        except ImportError:
+        except ImportError as e:
             raise RuntimeError(
                 "uWSGI could not be imported, are you running under uWSGI?"
-            )
+            ) from e
 
         self.cache = cache
 

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -4,12 +4,25 @@ from common import CommonTests
 from has import HasTests
 
 from cachelib import RedisCache
+from cachelib.serializers import RedisSerializer
 
 
-@pytest.fixture(autouse=True)
+class SillySerializer:
+    """A pointless serializer only for testing"""
+
+    def dumps(self, value):
+        return repr(value).encode()
+
+    def loads(self, bvalue):
+        if bvalue is None:
+            return None
+        return eval(bvalue.decode())
+
+
+@pytest.fixture(autouse=True, params=[RedisSerializer, SillySerializer])
 def cache_factory(request):
     def _factory(self, *args, **kwargs):
-        rc = RedisCache(*args, port=6360, **kwargs)
+        rc = RedisCache(*args, port=6360, serializer=request.param(), **kwargs)
         rc._client.flushdb()
         return rc
 

--- a/tests/test_simple_cache.py
+++ b/tests/test_simple_cache.py
@@ -5,12 +5,23 @@ from common import CommonTests
 from has import HasTests
 
 from cachelib import SimpleCache
+from cachelib.serializers import SimpleSerializer
 
 
-@pytest.fixture(autouse=True)
+class SillySerializer:
+    """A pointless serializer only for testing"""
+
+    def dumps(self, value):
+        return repr(value).encode()
+
+    def loads(self, bvalue):
+        return eval(bvalue.decode())
+
+
+@pytest.fixture(autouse=True, params=[SimpleSerializer, SillySerializer])
 def cache_factory(request):
     def _factory(self, *args, **kwargs):
-        return SimpleCache(*args, **kwargs)
+        return SimpleCache(*args, serializer=request.param(), **kwargs)
 
     request.cls.cache_factory = _factory
 

--- a/tests/test_simple_cache.py
+++ b/tests/test_simple_cache.py
@@ -5,7 +5,6 @@ from common import CommonTests
 from has import HasTests
 
 from cachelib import SimpleCache
-from cachelib.serializers import SimpleSerializer
 
 
 class SillySerializer:
@@ -18,10 +17,20 @@ class SillySerializer:
         return eval(bvalue.decode())
 
 
-@pytest.fixture(autouse=True, params=[SimpleSerializer, SillySerializer])
+class CustomCache(SimpleCache):
+    """Our custom cache client with non-default serializer"""
+
+    # overwrite serializer
+    serializer = SillySerializer()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+@pytest.fixture(autouse=True, params=[SimpleCache, CustomCache])
 def cache_factory(request):
     def _factory(self, *args, **kwargs):
-        return SimpleCache(*args, serializer=request.param(), **kwargs)
+        return request.param(*args, **kwargs)
 
     request.cls.cache_factory = _factory
 

--- a/tests/test_uwsgi_cache.py
+++ b/tests/test_uwsgi_cache.py
@@ -1,4 +1,3 @@
-# type: ignore
 import pytest
 from clear import ClearTests
 from common import CommonTests

--- a/tests/test_uwsgi_cache.py
+++ b/tests/test_uwsgi_cache.py
@@ -4,7 +4,6 @@ from common import CommonTests
 from has import HasTests
 
 from cachelib import UWSGICache
-from cachelib.serializers import UWSGISerializer
 
 
 class SillySerializer:
@@ -17,10 +16,20 @@ class SillySerializer:
         return eval(bvalue.decode())
 
 
-@pytest.fixture(autouse=True, params=[UWSGISerializer, SillySerializer])
+class CustomCache(UWSGICache):
+    """Our custom cache client with non-default serializer"""
+
+    # overwrite serializer
+    serializer = SillySerializer()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+@pytest.fixture(autouse=True, params=[UWSGICache, CustomCache])
 def cache_factory(request):
     def _factory(self, *args, **kwargs):
-        uwc = UWSGICache(*args, serializer=request.param(), **kwargs)
+        uwc = request.param(*args, **kwargs)
         uwc.clear()
         return uwc
 

--- a/tests/test_uwsgi_cache.py
+++ b/tests/test_uwsgi_cache.py
@@ -1,15 +1,27 @@
+# type: ignore
 import pytest
 from clear import ClearTests
 from common import CommonTests
 from has import HasTests
 
 from cachelib import UWSGICache
+from cachelib.serializers import UWSGISerializer
 
 
-@pytest.fixture(autouse=True)
+class SillySerializer:
+    """A pointless serializer only for testing"""
+
+    def dumps(self, value):
+        return repr(value).encode()
+
+    def loads(self, bvalue):
+        return eval(bvalue.decode())
+
+
+@pytest.fixture(autouse=True, params=[UWSGISerializer, SillySerializer])
 def cache_factory(request):
     def _factory(self, *args, **kwargs):
-        uwc = UWSGICache(*args, **kwargs)
+        uwc = UWSGICache(*args, serializer=request.param(), **kwargs)
         uwc.clear()
         return uwc
 


### PR DESCRIPTION
Some initial work following #11 

- [x] Implement default serializers for each cache type
- [x] Move serializers into separate module
- [x] Extract common serialization logic to `BaseSerializer`
- [x] add deprecation warning for `RedisCache.dump_object` and `RedisCache.load_objec`t
- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
- [x]  Add new entry to changelog