### PR TITLE
Uniformize API

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,9 @@ jobs:
         run: brew install libmemcached memcached redis
       - name: install external dependencies Linux
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install libmemcached-dev memcached redis-server
+        run: |
+          sudo apt-get update
+          sudo apt-get install libmemcached-dev memcached redis-server
       - name: update pip
         run: |
           pip install -U wheel

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,9 @@ Version 0.4.0
 
 Unreleased
 
+-   All cache types now implement BaseCache interface both
+    in behavior and method return types. Thus, code written
+    for one cache type should work with any other cache type.
 -   Add type information for static typing tools. :pr:`48`
 -   ``FileNotFound`` exceptions will not be logged anymore
     in ``FileSystemCache`` methods in order to avoid polluting

--- a/src/cachelib/base.py
+++ b/src/cachelib/base.py
@@ -95,31 +95,35 @@ class BaseCache:
 
     def set_many(
         self, mapping: _t.Dict[str, _t.Any], timeout: _t.Optional[int] = None
-    ) -> bool:
+    ) -> _t.List[_t.Any]:
         """Sets multiple keys and values from a mapping.
 
         :param mapping: a mapping with the keys/values to set.
         :param timeout: the cache timeout for the key in seconds (if not
                         specified, it uses the default timeout). A timeout of
                         0 indicates that the cache never expires.
-        :returns: Whether all given keys have been set.
+        :returns: A list containing all keys sucessfuly set
         :rtype: boolean
         """
-        rv = True
+        set_keys = []
         for key, value in mapping.items():
-            if not self.set(key, value, timeout):
-                rv = False
-        return rv
+            if self.set(key, value, timeout):
+                set_keys.append(key)
+        return set_keys
 
-    def delete_many(self, *keys: str) -> bool:
+    def delete_many(self, *keys: str) -> _t.List[_t.Any]:
         """Deletes multiple keys at once.
 
         :param keys: The function accepts multiple keys as positional
                      arguments.
-        :returns: Whether all given keys have been deleted.
+        :returns: A list containing all sucessfuly deleted keys
         :rtype: boolean
         """
-        return all(self.delete(key) for key in keys)
+        deleted_keys = []
+        for key in keys:
+            if self.delete(key):
+                deleted_keys.append(key)
+        return deleted_keys
 
     def has(self, key: str) -> bool:
         """Checks if a key exists in the cache without returning it. This is a
@@ -171,7 +175,6 @@ class BaseCache:
 
 
 class NullCache(BaseCache):
-
     """A cache that doesn't cache.  This can be useful for unit testing.
 
     :param default_timeout: a dummy parameter that is ignored but exists

--- a/src/cachelib/base.py
+++ b/src/cachelib/base.py
@@ -95,7 +95,7 @@ class BaseCache:
 
     def set_many(
         self, mapping: _t.Dict[str, _t.Any], timeout: _t.Optional[int] = None
-    ) -> _t.Union[bool, _t.List[_t.Any]]:
+    ) -> bool:
         """Sets multiple keys and values from a mapping.
 
         :param mapping: a mapping with the keys/values to set.
@@ -111,7 +111,7 @@ class BaseCache:
                 rv = False
         return rv
 
-    def delete_many(self, *keys: str) -> _t.Union[bool, _t.Optional[int]]:
+    def delete_many(self, *keys: str) -> bool:
         """Deletes multiple keys at once.
 
         :param keys: The function accepts multiple keys as positional

--- a/src/cachelib/base.py
+++ b/src/cachelib/base.py
@@ -125,8 +125,6 @@ class BaseCache:
         """Checks if a key exists in the cache without returning it. This is a
         cheap operation that bypasses loading the actual data on the backend.
 
-        This method is optional and may not be implemented on all caches.
-
         :param key: the key to check
         """
         raise NotImplementedError(

--- a/src/cachelib/base.py
+++ b/src/cachelib/base.py
@@ -121,7 +121,7 @@ class BaseCache:
         """
         return all(self.delete(key) for key in keys)
 
-    def has(self, key: str) -> _t.Union[bool, int]:
+    def has(self, key: str) -> bool:
         """Checks if a key exists in the cache without returning it. This is a
         cheap operation that bypasses loading the actual data on the backend.
 

--- a/src/cachelib/base.py
+++ b/src/cachelib/base.py
@@ -26,7 +26,7 @@ class BaseCache:
         """
         return None
 
-    def delete(self, key: str) -> _t.Union[bool, int]:
+    def delete(self, key: str) -> bool:
         """Delete `key` from the cache.
 
         :param key: the key to delete.

--- a/src/cachelib/base.py
+++ b/src/cachelib/base.py
@@ -136,7 +136,7 @@ class BaseCache:
             "explicitly if you don't care about performance."
         )
 
-    def clear(self) -> _t.Union[bool, int]:
+    def clear(self) -> bool:
         """Clears the cache.  Keep in mind that not all caches support
         completely clearing the cache.
 

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -126,7 +126,9 @@ class MemcachedCache(BaseCache):
             new_mapping[key] = value
 
         timeout = self._normalize_timeout(timeout)
-        failed_keys = self._client.set_multi(new_mapping, timeout) # type: _t.List[_t.Any]
+        failed_keys = self._client.set_multi(
+            new_mapping, timeout
+        )  # type: _t.List[_t.Any]
         k_normkey = zip(mapping.keys(), new_mapping.keys())
         return [k for k, nkey in k_normkey if nkey not in failed_keys]
 

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -101,10 +101,10 @@ class MemcachedCache(BaseCache):
                     rv[key] = None
         return rv
 
-    def add(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> _t.Any:
+    def add(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> bool:
         key = self._normalize_key(key)
         timeout = self._normalize_timeout(timeout)
-        return self._client.add(key, value, timeout)
+        return bool(self._client.add(key, value, timeout))
 
     def set(
         self, key: str, value: _t.Any, timeout: _t.Optional[int] = None

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -135,13 +135,13 @@ class MemcachedCache(BaseCache):
             return bool(self._client.delete(key))
         return False
 
-    def delete_many(self, *keys: str) -> _t.Any:
+    def delete_many(self, *keys: str) -> bool:
         new_keys = []
         for key in keys:
             key = self._normalize_key(key)
             if _test_memcached_key(key):
                 new_keys.append(key)
-        return self._client.delete_multi(new_keys)
+        return bool(self._client.delete_multi(new_keys))
 
     def has(self, key: str) -> _t.Any:
         key = self._normalize_key(key)

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -127,10 +127,11 @@ class MemcachedCache(BaseCache):
         failed_keys = self._client.set_multi(new_mapping, timeout)
         return not failed_keys
 
-    def delete(self, key: str) -> _t.Any:
+    def delete(self, key: str) -> bool:
         key = self._normalize_key(key)
         if _test_memcached_key(key):
-            return self._client.delete(key)
+            return bool(self._client.delete(key))
+        return False
 
     def delete_many(self, *keys: str) -> _t.Any:
         new_keys = []

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -106,10 +106,12 @@ class MemcachedCache(BaseCache):
         timeout = self._normalize_timeout(timeout)
         return self._client.add(key, value, timeout)
 
-    def set(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> _t.Any:
+    def set(
+        self, key: str, value: _t.Any, timeout: _t.Optional[int] = None
+    ) -> _t.Optional[bool]:
         key = self._normalize_key(key)
         timeout = self._normalize_timeout(timeout)
-        return self._client.set(key, value, timeout)
+        return bool(self._client.set(key, value, timeout))
 
     def get_many(self, *keys: str) -> _t.List[_t.Any]:
         d = self.get_dict(*keys)

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -83,14 +83,14 @@ class MemcachedCache(BaseCache):
         if _test_memcached_key(key):
             return self._client.get(key)
 
-    def get_dict(self, *keys: str) -> _t.Any:
+    def get_dict(self, *keys: str) -> _t.Dict[str, _t.Any]:
         key_mapping = {}
         for key in keys:
             encoded_key = self._normalize_key(key)
             if _test_memcached_key(key):
                 key_mapping[encoded_key] = key
         _keys = list(key_mapping)
-        d = rv = self._client.get_multi(_keys)
+        d = rv = self._client.get_multi(_keys)  # type: _t.Dict[str, _t.Any]
         if self.key_prefix:
             rv = {}
             for key, value in d.items():
@@ -111,7 +111,7 @@ class MemcachedCache(BaseCache):
         timeout = self._normalize_timeout(timeout)
         return self._client.set(key, value, timeout)
 
-    def get_many(self, *keys: str) -> _t.Any:
+    def get_many(self, *keys: str) -> _t.List[_t.Any]:
         d = self.get_dict(*keys)
         return [d[key] for key in keys]
 

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -149,8 +149,8 @@ class MemcachedCache(BaseCache):
             return bool(self._client.append(key, ""))
         return False
 
-    def clear(self) -> _t.Any:
-        return self._client.flush_all()
+    def clear(self) -> bool:
+        return bool(self._client.flush_all())
 
     def inc(self, key: str, delta: int = 1) -> _t.Optional[int]:
         key = self._normalize_key(key)

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -143,10 +143,10 @@ class MemcachedCache(BaseCache):
                 new_keys.append(key)
         return bool(self._client.delete_multi(new_keys))
 
-    def has(self, key: str) -> _t.Any:
+    def has(self, key: str) -> bool:
         key = self._normalize_key(key)
         if _test_memcached_key(key):
-            return self._client.append(key, "")
+            return bool(self._client.append(key, ""))
         return False
 
     def clear(self) -> _t.Any:

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -140,8 +140,8 @@ class RedisCache(BaseCache):
             prefixed_keys = [k for k in keys]
         return bool(self._client.delete(*prefixed_keys))
 
-    def has(self, key: str) -> int:
-        return self._client.exists(self.key_prefix + key)
+    def has(self, key: str) -> bool:
+        return bool(self._client.exists(self.key_prefix + key))
 
     def clear(self) -> int:
         status = 0

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -114,7 +114,7 @@ class RedisCache(BaseCache):
 
     def set_many(
         self, mapping: _t.Dict[str, _t.Any], timeout: _t.Optional[int] = None
-    ) -> bool:
+    ) -> _t.List[_t.Any]:
         timeout = self._normalize_timeout(timeout)
         # Use transaction=False to batch without calling redis MULTI
         # which is not supported by twemproxy
@@ -126,19 +126,21 @@ class RedisCache(BaseCache):
                 pipe.set(name=self.key_prefix + key, value=dump)
             else:
                 pipe.setex(name=self.key_prefix + key, value=dump, time=timeout)
-        return bool(pipe.execute())
+        results = pipe.execute()
+        return [k for k, was_set in zip(mapping.keys(), results) if was_set]
 
     def delete(self, key: str) -> bool:
         return bool(self._client.delete(self.key_prefix + key))
 
-    def delete_many(self, *keys: str) -> bool:
+    def delete_many(self, *keys: str) -> _t.List[_t.Any]:
         if not keys:
-            return False
+            return []
         if self.key_prefix:
             prefixed_keys = [self.key_prefix + key for key in keys]
         else:
             prefixed_keys = [k for k in keys]
-        return bool(self._client.delete(*prefixed_keys))
+        self._client.delete(*prefixed_keys)
+        return [k for k in prefixed_keys if not self.has(k)]
 
     def has(self, key: str) -> bool:
         return bool(self._client.exists(self.key_prefix + key))

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -153,7 +153,7 @@ class RedisCache(BaseCache):
             status = self._client.flushdb()
         return bool(status)
 
-    def inc(self, key: str, delta: int = 1) -> int:
+    def inc(self, key: str, delta: int = 1) -> _t.Optional[int]:
         return self._client.incr(name=self.key_prefix + key, amount=delta)
 
     def dec(self, key: str, delta: int = 1) -> int:

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -156,5 +156,5 @@ class RedisCache(BaseCache):
     def inc(self, key: str, delta: int = 1) -> _t.Optional[int]:
         return self._client.incr(name=self.key_prefix + key, amount=delta)
 
-    def dec(self, key: str, delta: int = 1) -> int:
+    def dec(self, key: str, delta: int = 1) -> _t.Optional[int]:
         return self._client.incr(name=self.key_prefix + key, amount=-delta)

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -143,7 +143,7 @@ class RedisCache(BaseCache):
     def has(self, key: str) -> bool:
         return bool(self._client.exists(self.key_prefix + key))
 
-    def clear(self) -> int:
+    def clear(self) -> bool:
         status = 0
         if self.key_prefix:
             keys = self._client.keys(self.key_prefix + "*")
@@ -151,7 +151,7 @@ class RedisCache(BaseCache):
                 status = self._client.delete(*keys)
         else:
             status = self._client.flushdb()
-        return status
+        return bool(status)
 
     def inc(self, key: str, delta: int = 1) -> int:
         return self._client.incr(name=self.key_prefix + key, amount=delta)

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -128,8 +128,8 @@ class RedisCache(BaseCache):
                 pipe.setex(name=self.key_prefix + key, value=dump, time=timeout)
         return pipe.execute()
 
-    def delete(self, key: str) -> int:
-        return self._client.delete(self.key_prefix + key)
+    def delete(self, key: str) -> bool:
+        return bool(self._client.delete(self.key_prefix + key))
 
     def delete_many(self, *keys: str) -> _t.Optional[int]:
         if not keys:

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -22,8 +22,6 @@ class SimpleCache(BaseCache):
     def __init__(self, threshold: int = 500, default_timeout: int = 300):
         BaseCache.__init__(self, default_timeout)
         self._cache: _t.Dict[str, _t.Any] = {}
-        # mypy complains about mocks
-        self.clear = self._cache.clear  # type: ignore
         self._threshold = threshold or 500  # threshold = 0
 
     def _over_threshold(self) -> bool:
@@ -94,3 +92,7 @@ class SimpleCache(BaseCache):
             return bool(expires == 0 or expires > time())
         except KeyError:
             return False
+
+    def clear(self) -> bool:
+        self._cache.clear()
+        return not bool(self._cache)

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -68,7 +68,9 @@ class SimpleCache(BaseCache):
         except (KeyError, pickle.PickleError):
             return None
 
-    def set(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> bool:
+    def set(
+        self, key: str, value: _t.Any, timeout: _t.Optional[int] = None
+    ) -> _t.Optional[bool]:
         expires = self._normalize_timeout(timeout)
         self._prune()
         self._cache[key] = (expires, pickle.dumps(value, pickle.HIGHEST_PROTOCOL))

--- a/src/cachelib/uwsgi.py
+++ b/src/cachelib/uwsgi.py
@@ -46,8 +46,8 @@ class UWSGICache(BaseCache):
             return
         return pickle.loads(rv)
 
-    def delete(self, key: str) -> _t.Any:
-        return self._uwsgi.cache_del(key, self.cache)
+    def delete(self, key: str) -> bool:
+        return bool(self._uwsgi.cache_del(key, self.cache))
 
     def set(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> _t.Any:
         return self._uwsgi.cache_update(

--- a/src/cachelib/uwsgi.py
+++ b/src/cachelib/uwsgi.py
@@ -64,8 +64,8 @@ class UWSGICache(BaseCache):
             )
         )
 
-    def clear(self) -> _t.Any:
-        return self._uwsgi.cache_clear(self.cache)
+    def clear(self) -> bool:
+        return bool(self._uwsgi.cache_clear(self.cache))
 
     def has(self, key: str) -> bool:
         return self._uwsgi.cache_exists(key, self.cache) is not None

--- a/src/cachelib/uwsgi.py
+++ b/src/cachelib/uwsgi.py
@@ -57,9 +57,11 @@ class UWSGICache(BaseCache):
         )  # type: bool
         return result
 
-    def add(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> _t.Any:
-        return self._uwsgi.cache_set(
-            key, pickle.dumps(value), self._normalize_timeout(timeout), self.cache
+    def add(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> bool:
+        return bool(
+            self._uwsgi.cache_set(
+                key, pickle.dumps(value), self._normalize_timeout(timeout), self.cache
+            )
         )
 
     def clear(self) -> _t.Any:

--- a/src/cachelib/uwsgi.py
+++ b/src/cachelib/uwsgi.py
@@ -49,10 +49,13 @@ class UWSGICache(BaseCache):
     def delete(self, key: str) -> bool:
         return bool(self._uwsgi.cache_del(key, self.cache))
 
-    def set(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> _t.Any:
-        return self._uwsgi.cache_update(
+    def set(
+        self, key: str, value: _t.Any, timeout: _t.Optional[int] = None
+    ) -> _t.Optional[bool]:
+        result = self._uwsgi.cache_update(
             key, pickle.dumps(value), self._normalize_timeout(timeout), self.cache
-        )
+        )  # type: bool
+        return result
 
     def add(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> _t.Any:
         return self._uwsgi.cache_set(

--- a/tests/common.py
+++ b/tests/common.py
@@ -16,7 +16,8 @@ class CommonTests(TestData):
 
     def test_set_get_many(self):
         cache = self.cache_factory()
-        assert cache.set_many(self.sample_pairs)
+        result = cache.set_many(self.sample_pairs)
+        assert result == list(self.sample_pairs.keys())
         values = cache.get_many(*self.sample_pairs)
         assert values == list(self.sample_pairs.values())
 
@@ -36,7 +37,8 @@ class CommonTests(TestData):
     def test_delete_many(self):
         cache = self.cache_factory()
         cache.set_many(self.sample_pairs)
-        assert cache.delete_many(*self.sample_pairs)
+        result = cache.delete_many(*self.sample_pairs)
+        assert result == list(self.sample_pairs.keys())
         assert not any(cache.get_many(*self.sample_pairs))
 
     def test_add(self):

--- a/tests/test_base_cache.py
+++ b/tests/test_base_cache.py
@@ -44,12 +44,12 @@ class TestBaseCache:
         cache = self.cache_factory()
         keys = ["bacon", "spam", "eggs"]
         mapping = dict.fromkeys(keys, None)
-        assert cache.set_many(mapping)
+        assert cache.set_many(mapping) == keys
 
     def test_delete_many(self):
         cache = self.cache_factory()
         keys = ["bacon", "spam", "eggs"]
-        assert cache.delete_many(*keys)
+        assert cache.delete_many(*keys) == keys
 
     def test_has(self):
         cache = self.cache_factory()

--- a/tests/test_interface_uniformity.py
+++ b/tests/test_interface_uniformity.py
@@ -1,0 +1,32 @@
+# type: ignore
+import inspect
+
+import pytest
+
+from cachelib import BaseCache
+from cachelib import FileSystemCache
+from cachelib import MemcachedCache
+from cachelib import RedisCache
+from cachelib import SimpleCache
+
+
+@pytest.fixture(autouse=True)
+def create_cache_list(request, tmpdir):
+    mc = MemcachedCache()
+    mc._client.flush_all()
+    rc = RedisCache(port=6360)
+    rc._client.flushdb()
+    request.cls.cache_list = [FileSystemCache(tmpdir), mc, rc, SimpleCache()]
+
+
+@pytest.mark.usefixtures("redis_server", "memcached_server")
+class TestInterfaceUniformity:
+    def test_types_have_all_base_methods(self):
+        public_api_methods = [
+            meth
+            for meth in inspect.getmembers(BaseCache, predicate=inspect.isfunction)
+            if not meth[0].startswith("_")
+        ]
+        for cache_type in self.cache_list:
+            for meth in public_api_methods:
+                assert hasattr(cache_type, meth[0]) and callable(meth[1])

--- a/tests/test_simple_cache.py
+++ b/tests/test_simple_cache.py
@@ -1,6 +1,7 @@
 from time import sleep
 
 import pytest
+from clear import ClearTests
 from common import CommonTests
 from has import HasTests
 
@@ -15,7 +16,7 @@ def cache_factory(request):
     request.cls.cache_factory = _factory
 
 
-class TestSimpleCache(CommonTests, HasTests):
+class TestSimpleCache(CommonTests, HasTests, ClearTests):
     def test_threshold(self):
         threshold = len(self.sample_pairs) // 2
         cache = self.cache_factory(threshold=threshold)


### PR DESCRIPTION
Following #61

- [x] add changelog

Uniformize existing interface and type hints

- ~`get`~ (already ok)
- [x] `delete`
- [x] `get_many`
- [x] `get_dict`
- [x] `set`
- [x] `add`
- [x] `set_many`
- [x] `delete_many`
- [x] `has`
- [x] `clear`
- [x] `inc`
- [x] `dec`

Implement missing optional methods

- [x] `SimpleCache.clear`

Changes to API

- [x] `set_many` and `delete_many` methods now return `list` containing all set or deleted keys (respectively) instead of `bool`
