### PR TITLE
add xprocess startup callbacks to redis and memcached fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import warnings
 from pathlib import Path
 
@@ -41,6 +42,10 @@ def redis_server(xprocess):
     class Starter(ProcessStarter):
         pattern = "[Rr]eady to accept connections"
         args = ["redis-server", "--port 6360"]
+
+        def startup_check(self):
+            out = subprocess.run(["redis-cli", "ping"], capture_output=True)
+            return out.stdout == b"PONG\n"
 
     xprocess.ensure(package_name, Starter)
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,10 @@ def memcached_server(xprocess):
         pattern = "server listening"
         args = ["memcached", "-vv"]
 
+        def startup_check(self):
+            out = subprocess.run(["memcached"], capture_output=True)
+            return b"Address already" in out.stderr
+
     xprocess.ensure(package_name, Starter)
     yield
     xprocess.getinfo(package_name).terminate()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def redis_server(xprocess):
         args = ["redis-server", "--port 6360"]
 
         def startup_check(self):
-            out = subprocess.run(["redis-cli", "ping"], capture_output=True)
+            out = subprocess.run(["redis-cli", "ping"], stdout=subprocess.PIPE)
             return out.stdout == b"PONG\n"
 
     xprocess.ensure(package_name, Starter)
@@ -64,7 +64,7 @@ def memcached_server(xprocess):
         args = ["memcached", "-vv"]
 
         def startup_check(self):
-            out = subprocess.run(["memcached"], capture_output=True)
+            out = subprocess.run(["memcached"], stderr=subprocess.PIPE)
             return b"Address already" in out.stderr
 
     xprocess.ensure(package_name, Starter)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,9 @@ def redis_server(xprocess):
         args = ["redis-server", "--port 6360"]
 
         def startup_check(self):
-            out = subprocess.run(["redis-cli", "ping"], stdout=subprocess.PIPE)
+            out = subprocess.run(
+                ["redis-cli", "-p", "6360", "ping"], stdout=subprocess.PIPE
+            )
             return out.stdout == b"PONG\n"
 
     xprocess.ensure(package_name, Starter)


### PR DESCRIPTION
Following #36 

Add startup callback to following fixtures:
- [x] redis_server
- [x] memcached_server