### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Version 0.5.0
 -------------
 
-Unreleased
+Released 2021-12-31
 
 -   Cache types now have configurable serializers. :pr:`63`
 

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -15,4 +15,4 @@ __all__ = [
     "RedisCache",
     "UWSGICache",
 ]
-__version__ = "0.4.1"
+__version__ = "0.5.0"


### PR DESCRIPTION
Our 0.5.0 release 🎉 

This release adds configurable serialization to `cachelib` #63 