### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,12 @@
 Version 0.6.0
 -------------
 
-Unreleased
+Released  2022-01-18
 
 - A custom ``hash_method`` may now be provided to ``FileSystemCache`` for
   hashing keys. :pr:`107`
 
-- Fix ``PermissionError`` issue with ``FileSystemCache`` on Windows. :pr:111
+- Fix ``PermissionError`` issue with ``FileSystemCache`` on Windows. :pr:`111`
 
 
 Version 0.5.0

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -15,4 +15,4 @@ __all__ = [
     "RedisCache",
     "UWSGICache",
 ]
-__version__ = "0.5.0"
+__version__ = "0.6.0"


### PR DESCRIPTION
Our 0.6.0 release 🎉 

**Change Summary**

- A custom ``hash_method`` may now be provided to ``FileSystemCache`` for
  hashing keys. #107 

- Fix ``PermissionError`` issue with ``FileSystemCache`` on Windows. #111 